### PR TITLE
Use golang.org package instead of code.google

### DIFF
--- a/deployer/deployer_web.go
+++ b/deployer/deployer_web.go
@@ -3,7 +3,7 @@ package deployer
 import (
 	"fmt"
 
-	"code.google.com/p/go.net/websocket"
+	"golang.org/x/net/websocket"
 
 	"github.com/gorilla/mux"
 	"github.com/abourget/slick"


### PR DESCRIPTION
Hi @abourget,

Thanks for the cool bot library. I'm just running the example bot and ran into an issue installing `code.google.com/p/go.net/websocket` with `go get`. It looks like the project has [moved away](https://groups.google.com/forum/#!topic/golang-dev/sckirqOWepg%5B1-25%5D) from Google Code and this is its new home.

Let me know if I'm wrong but it compiled fine against the new target.