### PR TITLE
Fixed timezone breakage in `standup` package unit-tests.

### DIFF
--- a/standup/standupData_test.go
+++ b/standup/standupData_test.go
@@ -47,7 +47,10 @@ func getTestStandupMap() standupMap {
 	}
 
 	var unixDate int64 = 1431921600 // 2015-May-18
-	sds := []standupDate{unixToStandupDate(unixDate), unixToStandupDate(unixDate).next()}
+	sds := []standupDate{
+		unixToStandupDate(unixDate),
+		unixToStandupDate(unixDate).next(),
+	}
 
 	for i := 0; i < 2; i += 1 {
 		uA.data.Yesterday = strconv.Itoa(i)

--- a/standup/standupDate.go
+++ b/standup/standupDate.go
@@ -21,7 +21,7 @@ func getStandupDate(daysFromToday int) standupDate {
 }
 
 func unixToStandupDate(unix int64) standupDate {
-	d := time.Unix(unix, 0)
+	d := time.Unix(unix, 0).UTC()
 	return standupDate{
 		year:  d.Year(),
 		month: d.Month(),


### PR DESCRIPTION
Use `.UTC()` after reading unix timestamps to ensure local TZ doesn't change
  the test case outcome.